### PR TITLE
Adds backend logic for getting next project to judge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@next/font": "^13.1.3",
-        "@prisma/client": "^4.8.0",
+        "@prisma/client": "^4.9.0",
         "@stdlib/math-base-special-betaln": "^0.0.6",
         "@stdlib/math-base-special-digamma": "^0.0.6",
         "@tanstack/react-query": "^4.20.0",
@@ -17,6 +17,7 @@
         "@trpc/next": "^10.8.1",
         "@trpc/react-query": "^10.8.1",
         "@trpc/server": "^10.8.1",
+        "array-shuffle": "^3.0.0",
         "clsx": "^1.2.1",
         "luxon": "^3.2.1",
         "next": "13.1.1",
@@ -41,7 +42,7 @@
         "postcss": "^8.4.14",
         "prettier": "^2.8.1",
         "prettier-plugin-tailwindcss": "^0.2.1",
-        "prisma": "^4.8.0",
+        "prisma": "^4.9.0",
         "tailwindcss": "^3.2.0",
         "typescript": "^4.9.4"
       }
@@ -2342,12 +2343,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.1.tgz",
-      "integrity": "sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.9.0.tgz",
+      "integrity": "sha512-bz6QARw54sWcbyR1lLnF2QHvRW5R/Jxnbbmwh3u+969vUKXtBkXgSgjDA85nji31ZBlf7+FrHDy5x+5ydGyQDg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
+        "@prisma/engines-version": "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
       },
       "engines": {
         "node": ">=14.17"
@@ -2362,16 +2363,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.1.tgz",
-      "integrity": "sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.9.0.tgz",
+      "integrity": "sha512-t1pt0Gsp+HcgPJrHFc+d/ZSAaKKWar2G/iakrE07yeKPNavDP3iVKPpfXP22OTCHZUWf7OelwKJxQgKAm5hkgw==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
-      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
+      "version": "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5.tgz",
+      "integrity": "sha512-M16aibbxi/FhW7z1sJCX8u+0DriyQYY5AyeTH7plQm9MLnURoiyn3CZBqAyIoQ+Z1pS77usCIibYJWSgleBMBA=="
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.2.0",
@@ -7187,6 +7188,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-shuffle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-3.0.0.tgz",
+      "integrity": "sha512-rogEGxHOQPhslOhpg12LJkB+bbAl484/s2AJq0BxtzQDQfKl76fS2u9zWgg3p3b9ENcuvE7K8A7l5ddiPjCRnw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -10404,13 +10416,13 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prisma": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.1.tgz",
-      "integrity": "sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.9.0.tgz",
+      "integrity": "sha512-bS96oZ5oDFXYgoF2l7PJ3Mp1wWWfLOo8B/jAfbA2Pn0Wm5Z/owBHzaMQKS3i1CzVBDWWPVnOohmbJmjvkcHS5w==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.8.1"
+        "@prisma/engines": "4.9.0"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -12969,23 +12981,23 @@
       }
     },
     "@prisma/client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.1.tgz",
-      "integrity": "sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.9.0.tgz",
+      "integrity": "sha512-bz6QARw54sWcbyR1lLnF2QHvRW5R/Jxnbbmwh3u+969vUKXtBkXgSgjDA85nji31ZBlf7+FrHDy5x+5ydGyQDg==",
       "requires": {
-        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
+        "@prisma/engines-version": "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
       }
     },
     "@prisma/engines": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.1.tgz",
-      "integrity": "sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.9.0.tgz",
+      "integrity": "sha512-t1pt0Gsp+HcgPJrHFc+d/ZSAaKKWar2G/iakrE07yeKPNavDP3iVKPpfXP22OTCHZUWf7OelwKJxQgKAm5hkgw==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
-      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
+      "version": "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5.tgz",
+      "integrity": "sha512-M16aibbxi/FhW7z1sJCX8u+0DriyQYY5AyeTH7plQm9MLnURoiyn3CZBqAyIoQ+Z1pS77usCIibYJWSgleBMBA=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",
@@ -14826,6 +14838,11 @@
         "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       }
+    },
+    "array-shuffle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-3.0.0.tgz",
+      "integrity": "sha512-rogEGxHOQPhslOhpg12LJkB+bbAl484/s2AJq0BxtzQDQfKl76fS2u9zWgg3p3b9ENcuvE7K8A7l5ddiPjCRnw=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -17110,12 +17127,12 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "prisma": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.1.tgz",
-      "integrity": "sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.9.0.tgz",
+      "integrity": "sha512-bS96oZ5oDFXYgoF2l7PJ3Mp1wWWfLOo8B/jAfbA2Pn0Wm5Z/owBHzaMQKS3i1CzVBDWWPVnOohmbJmjvkcHS5w==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.8.1"
+        "@prisma/engines": "4.9.0"
       }
     },
     "prop-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tartanhacks-judging",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@next/font": "^13.1.3",
-    "@prisma/client": "^4.8.0",
+    "@prisma/client": "^4.9.0",
     "@stdlib/math-base-special-betaln": "^0.0.6",
     "@stdlib/math-base-special-digamma": "^0.0.6",
     "@tanstack/react-query": "^4.20.0",
@@ -19,6 +19,7 @@
     "@trpc/next": "^10.8.1",
     "@trpc/react-query": "^10.8.1",
     "@trpc/server": "^10.8.1",
+    "array-shuffle": "^3.0.0",
     "clsx": "^1.2.1",
     "luxon": "^3.2.1",
     "next": "13.1.1",
@@ -43,7 +44,7 @@
     "postcss": "^8.4.14",
     "prettier": "^2.8.1",
     "prettier-plugin-tailwindcss": "^0.2.1",
-    "prisma": "^4.8.0",
+    "prisma": "^4.9.0",
     "tailwindcss": "^3.2.0",
     "typescript": "^4.9.4"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,7 +96,7 @@ model JudgingInstance {
     id          String @id @default(cuid()) @map("_id")
     prizeId     String
     projectId   String
-    timesJudged Int
+    timesJudged Int    @default(0)
 
     prize   Prize   @relation(fields: [prizeId], references: [id])
     project Project @relation(fields: [projectId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,8 @@ model Judge {
     ignoredProjects  IgnoreProjects[]
     judgments        ProjectComparisonResult[]
 
+    updatedAt DateTime @updatedAt
+
     @@unique([helixId])
 }
 
@@ -91,9 +93,10 @@ model IgnoreProjects {
 
 // Information tied to a project-prize tuple used to determine ranking
 model JudgingInstance {
-    id        String @id @default(cuid()) @map("_id")
-    prizeId   String
-    projectId String
+    id          String @id @default(cuid()) @map("_id")
+    prizeId     String
+    projectId   String
+    timesJudged Int
 
     prize   Prize   @relation(fields: [prizeId], references: [id])
     project Project @relation(fields: [projectId], references: [id])

--- a/src/pages/api/synchronize.ts
+++ b/src/pages/api/synchronize.ts
@@ -109,7 +109,7 @@ async function synchronizeProjects() {
     )
   );
 
-  // Upsert project-prize relations
+  // Upsert judging instances
   await prisma.$transaction(
     prizeRelations.map((relation) =>
       prisma.judgingInstance.upsert({

--- a/src/server/api/routers/judging.ts
+++ b/src/server/api/routers/judging.ts
@@ -11,26 +11,26 @@ export const judgingRouter = createTRPCRouter({
   getNext: protectedProcedure.query(async ({ ctx }) => {
     // TODO: Return next project to be assigned
     const user = ctx?.session?.user as HelixUser;
-    const judge = await prisma?.judge.findFirst({
+    const judge = await ctx.prisma.judge.findFirst({
       where: { helixId: user._id },
       include: {
         prizeAssignments: {
           include: {
             leadingProject: {
               include: {
-                judgingInstances: {},
+                judgingInstances: true,
               },
             },
           },
         },
-        ignoredProjects: {},
+        ignoredProjects: true,
       },
     });
     if (!judge) {
       return null;
     }
 
-    return await getNext(judge);
+    return await getNext(judge, ctx.prisma);
   }),
   compare: protectedProcedure
     .input(

--- a/src/server/api/routers/judging.ts
+++ b/src/server/api/routers/judging.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { HelixUser } from "../../../types/user";
+import { getNext } from "../../controllers/getNext";
 import authMiddleware from "../middleware/authMiddleware";
 
 import { createTRPCRouter, publicProcedure } from "../trpc";
@@ -7,14 +8,29 @@ import { createTRPCRouter, publicProcedure } from "../trpc";
 const protectedProcedure = publicProcedure.use(authMiddleware);
 
 export const judgingRouter = createTRPCRouter({
-  getNext: protectedProcedure.query(async ({ ctx, input }) => {
+  getNext: protectedProcedure.query(async ({ ctx }) => {
     // TODO: Return next project to be assigned
     const user = ctx?.session?.user as HelixUser;
     const judge = await prisma?.judge.findFirst({
       where: { helixId: user._id },
+      include: {
+        prizeAssignments: {
+          include: {
+            leadingProject: {
+              include: {
+                judgingInstances: {},
+              },
+            },
+          },
+        },
+        ignoredProjects: {},
+      },
     });
+    if (!judge) {
+      return null;
+    }
 
-    return;
+    return await getNext(judge);
   }),
   compare: protectedProcedure
     .input(

--- a/src/server/controllers/getNext.ts
+++ b/src/server/controllers/getNext.ts
@@ -1,0 +1,131 @@
+import type {
+  IgnoreProjects,
+  Judge,
+  JudgePrizeAssignment,
+  JudgingInstance,
+  Project,
+} from "@prisma/client";
+import arrayShuffle from "array-shuffle";
+import { argmax, EPSILON, expected_information_gain } from "../utils/crowd-bt";
+import { mapReduce, mapReducePartial } from "../utils/fp";
+
+type JudgeNext = Judge & {
+  prizeAssignments: (JudgePrizeAssignment & {
+    leadingProject: ProjectNext;
+  })[];
+  ignoredProjects: IgnoreProjects[];
+};
+type ProjectNext = Project & {
+  judgingInstances: JudgingInstance[];
+};
+
+const MIN_VIEWS = 1;
+const TIMEOUT = 5 * 60 * 1000; // in milliseconds
+
+const _preferred_projects = async (
+  judge: JudgeNext
+): Promise<ProjectNext[]> => {
+  const ignoredIds = judge.ignoredProjects.map((ip) => ip.projectId);
+  const prizeIds = judge.prizeAssignments.map((pa) => pa.prizeId);
+  const projects = await prisma?.project.findMany({
+    where: {
+      id: {
+        notIn: ignoredIds,
+      },
+    },
+    include: {
+      judgingInstances: {
+        where: {
+          prizeId: {
+            in: prizeIds,
+          },
+        },
+      },
+    },
+  });
+  if (projects == null) {
+    return [];
+  }
+  const cutoff = new Date(Date.now() - TIMEOUT);
+  const busyJudges = await prisma?.judge.findMany({
+    where: {
+      updatedAt: {
+        gte: cutoff,
+      },
+    },
+  });
+  const busyProjects = busyJudges?.map((bj) => bj.nextProjectId);
+  const unbusyProjects = projects.filter((project) =>
+    busyProjects?.includes(project.id)
+  );
+  const candidateProjects = unbusyProjects ? unbusyProjects : projects;
+  const getUnderviewedCount = mapReducePartial(
+    (ji: JudgingInstance) => (ji.timesJudged < MIN_VIEWS ? 1 : 0),
+    (x, y) => x + y,
+    0
+  );
+  const maxUnderviewedCount = mapReduce(
+    (project) => getUnderviewedCount(project.judgingInstances),
+    (x, y) => Math.max(x, y),
+    0,
+    candidateProjects
+  );
+  return maxUnderviewedCount > 0
+    ? candidateProjects.filter(
+        (project) =>
+          getUnderviewedCount(project.judgingInstances) == maxUnderviewedCount
+      )
+    : candidateProjects;
+};
+
+export const getNext = async (
+  judge: JudgeNext
+): Promise<Project | null | undefined> => {
+  const preferred_projects = await _preferred_projects(judge);
+  if (!preferred_projects) {
+    return null;
+  }
+
+  const getPrizeLeader = async (
+    pa: JudgePrizeAssignment
+  ): Promise<[string, JudgingInstance]> => {
+    const leadingProject = (await prisma?.project.findUnique({
+      where: { id: pa.leadingProjectId },
+      include: {
+        judgingInstances: {
+          where: {
+            prizeId: pa.prizeId,
+          },
+        },
+      },
+    })) as ProjectNext;
+    return [pa.prizeId, leadingProject.judgingInstances[0] as JudgingInstance];
+  };
+  const prizeBests = new Map(
+    await Promise.all(judge.prizeAssignments.map(getPrizeLeader))
+  );
+
+  const shuffled_projects = arrayShuffle(preferred_projects);
+  if (Math.random() < EPSILON) {
+    return shuffled_projects[0];
+  } else {
+    return argmax(
+      (project) =>
+        mapReduce(
+          (ji) =>
+            expected_information_gain(
+              judge.alpha,
+              judge.beta,
+              (prizeBests.get(ji.prizeId) as JudgingInstance).mu,
+              (prizeBests.get(ji.prizeId) as JudgingInstance).sigma2,
+              ji.mu,
+              ji.sigma2
+            ),
+          (x, y) => x + y,
+          0,
+          project.judgingInstances
+        ),
+      shuffled_projects
+    );
+  }
+};

--- a/src/server/controllers/getNext.ts
+++ b/src/server/controllers/getNext.ts
@@ -86,7 +86,7 @@ export const getNext = async (
   prisma: PrismaClient
 ): Promise<Project | null | undefined> => {
   const preferredProjects = await getPreferredProjects(judge, prisma);
-  if (!preferredProjects) {
+  if (!preferredProjects || preferredProjects?.length == 0) {
     return null;
   }
 

--- a/src/server/utils/crowd-bt.ts
+++ b/src/server/utils/crowd-bt.ts
@@ -4,8 +4,8 @@
  * https://github.com/anishathalye/gavel/blob/master/gavel/crowd_bt.py
  */
 
-import betaln from "@stdlib/math-base-special-betaln/docs/types";
-import digamma from "@stdlib/math-base-special-digamma/docs/types";
+import betaln from "@stdlib/math-base-special-betaln";
+import digamma from "@stdlib/math-base-special-digamma";
 import { id, uproduct } from "./fp";
 
 /* See this paper for more information:

--- a/src/server/utils/crowd-bt.ts
+++ b/src/server/utils/crowd-bt.ts
@@ -27,203 +27,187 @@ function argmax<T>(f: (x: T) => number, xs: T[]): T {
   return xs.map(uproduct(f, id)).reduce(update)[1];
 }
 
-const divergence_gaussian = (
-  mu_1: number,
-  sigma_sq_1: number,
-  mu_2: number,
-  sigma_sq_2: number
+const divergenceGaussian = (
+  mu1: number,
+  sigmaSq1: number,
+  mu2: number,
+  sigmaSq2: number
 ): number => {
-  const ratio = sigma_sq_1 / sigma_sq_2;
-  return (
-    (mu_1 - mu_2) ** 2 / (2 * sigma_sq_2) + (ratio - 1 - Math.log(ratio)) / 2
-  );
+  const ratio = sigmaSq1 / sigmaSq2;
+  return (mu1 - mu2) ** 2 / (2 * sigmaSq2) + (ratio - 1 - Math.log(ratio)) / 2;
 };
 
-const divergence_beta = (
-  alpha_1: number,
-  beta_1: number,
-  alpha_2: number,
-  beta_2: number
+const divergenceBeta = (
+  alpha1: number,
+  beta1: number,
+  alpha2: number,
+  beta2: number
 ): number => {
   return (
-    betaln(alpha_2, beta_2) -
-    betaln(alpha_1, beta_1) +
-    (alpha_1 - alpha_2) * digamma(alpha_1) +
-    (beta_1 - beta_2) * digamma(beta_1) +
-    (alpha_2 - alpha_1 + beta_2 - beta_1) * digamma(alpha_1 + beta_1)
+    betaln(alpha2, beta2) -
+    betaln(alpha1, beta1) +
+    (alpha1 - alpha2) * digamma(alpha1) +
+    (beta1 - beta2) * digamma(beta1) +
+    (alpha2 - alpha1 + beta2 - beta1) * digamma(alpha1 + beta1)
   );
 };
 
 const update = (
   alpha: number,
   beta: number,
-  mu_winner: number,
-  sigma_sq_winner: number,
-  mu_loser: number,
-  sigma_sq_loser: number
+  muWinner: number,
+  sigmaSqWinner: number,
+  muLoser: number,
+  sigmaSqLoser: number
 ): [number, number, number, number, number, number] => {
-  const [updated_alpha, updated_beta] = _updated_annotator(
+  const [updatedAlpha, updatedBeta] = updatedAnnotator(
     alpha,
     beta,
-    mu_winner,
-    sigma_sq_winner,
-    mu_loser,
-    sigma_sq_loser
+    muWinner,
+    sigmaSqWinner,
+    muLoser,
+    sigmaSqLoser
   );
-  const [updated_mu_winner, updated_mu_loser] = _updated_mus(
+  const [updatedMuWinner, updatedMuLoser] = updatedMus(
     alpha,
     beta,
-    mu_winner,
-    sigma_sq_winner,
-    mu_loser,
-    sigma_sq_loser
+    muWinner,
+    sigmaSqWinner,
+    muLoser,
+    sigmaSqLoser
   );
-  const [updated_sigma_sq_winner, updated_sigma_sq_loser] = _updated_sigma_sqs(
+  const [updatedSigmaSqWinner, updatedSigmaSqLoser] = updatedSigmaSqs(
     alpha,
     beta,
-    mu_winner,
-    sigma_sq_winner,
-    mu_loser,
-    sigma_sq_loser
+    muWinner,
+    sigmaSqWinner,
+    muLoser,
+    sigmaSqLoser
   );
   return [
-    updated_alpha,
-    updated_beta,
-    updated_mu_winner,
-    updated_sigma_sq_winner,
-    updated_mu_loser,
-    updated_sigma_sq_loser,
+    updatedAlpha,
+    updatedBeta,
+    updatedMuWinner,
+    updatedSigmaSqWinner,
+    updatedMuLoser,
+    updatedSigmaSqLoser,
   ];
 };
 
-const expected_information_gain = (
+const expectedInformationGain = (
   alpha: number,
   beta: number,
-  mu_a: number,
-  sigma_sq_a: number,
-  mu_b: number,
-  sigma_sq_b: number
+  muA: number,
+  sigmaSqA: number,
+  muB: number,
+  sigmaSqB: number
 ): number => {
-  const [alpha_1, beta_1, c] = _updated_annotator(
+  const [alpha1, beta1, c] = updatedAnnotator(
     alpha,
     beta,
-    mu_a,
-    sigma_sq_a,
-    mu_b,
-    sigma_sq_b
+    muA,
+    sigmaSqA,
+    muB,
+    sigmaSqB
   );
-  const [mu_a_1, mu_b_1] = _updated_mus(
+  const [muA1, muB1] = updatedMus(alpha, beta, muA, sigmaSqA, muB, sigmaSqB);
+  const [sigmaSqA1, sigmaSqB1] = updatedSigmaSqs(
     alpha,
     beta,
-    mu_a,
-    sigma_sq_a,
-    mu_b,
-    sigma_sq_b
+    muA,
+    sigmaSqA,
+    muB,
+    sigmaSqB
   );
-  const [sigma_sq_a_1, sigma_sq_b_1] = _updated_sigma_sqs(
+  const probARankedAbove = c;
+  const [alpha2, beta2] = updatedAnnotator(
     alpha,
     beta,
-    mu_a,
-    sigma_sq_a,
-    mu_b,
-    sigma_sq_b
+    muB,
+    sigmaSqB,
+    muA,
+    sigmaSqA
   );
-  const prob_a_ranked_above = c;
-  const [alpha_2, beta_2] = _updated_annotator(
+  const [muB2, muA2] = updatedMus(alpha, beta, muB, sigmaSqB, muA, sigmaSqA);
+  const [sigmaSqB2, sigmaSqA2] = updatedSigmaSqs(
     alpha,
     beta,
-    mu_b,
-    sigma_sq_b,
-    mu_a,
-    sigma_sq_a
-  );
-  const [mu_b_2, mu_a_2] = _updated_mus(
-    alpha,
-    beta,
-    mu_b,
-    sigma_sq_b,
-    mu_a,
-    sigma_sq_a
-  );
-  const [sigma_sq_b_2, sigma_sq_a_2] = _updated_sigma_sqs(
-    alpha,
-    beta,
-    mu_b,
-    sigma_sq_b,
-    mu_a,
-    sigma_sq_a
+    muB,
+    sigmaSqB,
+    muA,
+    sigmaSqA
   );
 
   return (
-    prob_a_ranked_above *
-      (divergence_gaussian(mu_a_1, sigma_sq_a_1, mu_a, sigma_sq_a) +
-        divergence_gaussian(mu_b_1, sigma_sq_b_1, mu_b, sigma_sq_b) +
-        GAMMA * divergence_beta(alpha_1, beta_1, alpha, beta)) +
-    (1 - prob_a_ranked_above) *
-      (divergence_gaussian(mu_a_2, sigma_sq_a_2, mu_a, sigma_sq_a) +
-        divergence_gaussian(mu_b_2, sigma_sq_b_2, mu_b, sigma_sq_b) +
-        GAMMA * divergence_beta(alpha_2, beta_2, alpha, beta))
+    probARankedAbove *
+      (divergenceGaussian(muA1, sigmaSqA1, muA, sigmaSqA) +
+        divergenceGaussian(muB1, sigmaSqB1, muB, sigmaSqB) +
+        GAMMA * divergenceBeta(alpha1, beta1, alpha, beta)) +
+    (1 - probARankedAbove) *
+      (divergenceGaussian(muA2, sigmaSqA2, muA, sigmaSqA) +
+        divergenceGaussian(muB2, sigmaSqB2, muB, sigmaSqB) +
+        GAMMA * divergenceBeta(alpha2, beta2, alpha, beta))
   );
 };
 // returns (updated mu of winner, updated mu of loser)
-const _updated_mus = (
+const updatedMus = (
   alpha: number,
   beta: number,
-  mu_winner: number,
-  sigma_sq_winner: number,
-  mu_loser: number,
-  sigma_sq_loser: number
+  muWinner: number,
+  sigmaSqWinner: number,
+  muLoser: number,
+  sigmaSqLoser: number
 ): [number, number] => {
   const mult =
-    (alpha * Math.exp(mu_winner)) /
-      (alpha * Math.exp(mu_winner) + beta * Math.exp(mu_loser)) -
-    Math.exp(mu_winner) / (Math.exp(mu_winner) + Math.exp(mu_loser));
-  const updated_mu_winner = mu_winner + sigma_sq_winner * mult;
-  const updated_mu_loser = mu_loser - sigma_sq_loser * mult;
+    (alpha * Math.exp(muWinner)) /
+      (alpha * Math.exp(muWinner) + beta * Math.exp(muLoser)) -
+    Math.exp(muWinner) / (Math.exp(muWinner) + Math.exp(muLoser));
+  const updatedMuWinner = muWinner + sigmaSqWinner * mult;
+  const updatedMuLoser = muLoser - sigmaSqLoser * mult;
 
-  return [updated_mu_winner, updated_mu_loser];
+  return [updatedMuWinner, updatedMuLoser];
 };
 
 // returns (updated sigma squared of winner, updated sigma squared of loser)
-const _updated_sigma_sqs = (
+const updatedSigmaSqs = (
   alpha: number,
   beta: number,
-  mu_winner: number,
-  sigma_sq_winner: number,
-  mu_loser: number,
-  sigma_sq_loser: number
+  muWinner: number,
+  sigmaSqWinner: number,
+  muLoser: number,
+  sigmaSqLoser: number
 ): [number, number] => {
   const mult =
-    (alpha * Math.exp(mu_winner) * beta * Math.exp(mu_loser)) /
-      (alpha * Math.exp(mu_winner) + beta * Math.exp(mu_loser)) ** 2 -
-    (Math.exp(mu_winner) * Math.exp(mu_loser)) /
-      (Math.exp(mu_winner) + Math.exp(mu_loser)) ** 2;
+    (alpha * Math.exp(muWinner) * beta * Math.exp(muLoser)) /
+      (alpha * Math.exp(muWinner) + beta * Math.exp(muLoser)) ** 2 -
+    (Math.exp(muWinner) * Math.exp(muLoser)) /
+      (Math.exp(muWinner) + Math.exp(muLoser)) ** 2;
 
-  const updated_sigma_sq_winner =
-    sigma_sq_winner * Math.max(1 + sigma_sq_winner * mult, KAPPA);
-  const updated_sigma_sq_loser =
-    sigma_sq_loser * Math.max(1 + sigma_sq_loser * mult, KAPPA);
+  const updatedSigmaSqWinner =
+    sigmaSqWinner * Math.max(1 + sigmaSqWinner * mult, KAPPA);
+  const updatedSigmaSqLoser =
+    sigmaSqLoser * Math.max(1 + sigmaSqLoser * mult, KAPPA);
 
-  return [updated_sigma_sq_winner, updated_sigma_sq_loser];
+  return [updatedSigmaSqWinner, updatedSigmaSqLoser];
 };
 
 // returns (updated alpha, updated beta, pr i >k j which is c)
-const _updated_annotator = (
+const updatedAnnotator = (
   alpha: number,
   beta: number,
-  mu_winner: number,
-  sigma_sq_winner: number,
-  mu_loser: number,
-  sigma_sq_loser: number
+  muWinner: number,
+  sigmaSqWinner: number,
+  muLoser: number,
+  sigmaSqLoser: number
 ): [number, number, number] => {
   const c_1 =
-    Math.exp(mu_winner) / (Math.exp(mu_winner) + Math.exp(mu_loser)) +
+    Math.exp(muWinner) / (Math.exp(muWinner) + Math.exp(muLoser)) +
     (0.5 *
-      (sigma_sq_winner + sigma_sq_loser) *
-      (Math.exp(mu_winner) *
-        Math.exp(mu_loser) *
-        (Math.exp(mu_loser) - Math.exp(mu_winner)))) /
-      (Math.exp(mu_winner) + Math.exp(mu_loser)) ** 3;
+      (sigmaSqWinner + sigmaSqLoser) *
+      (Math.exp(muWinner) *
+        Math.exp(muLoser) *
+        (Math.exp(muLoser) - Math.exp(muWinner)))) /
+      (Math.exp(muWinner) + Math.exp(muLoser)) ** 3;
   const c_2 = 1 - c_1;
   const c = (c_1 * alpha + c_2 * beta) / (alpha + beta);
 
@@ -236,18 +220,18 @@ const _updated_annotator = (
     (c * (alpha + beta + 2) * (alpha + beta + 1) * (alpha + beta));
 
   const variance = expt_sq - expt ** 2;
-  const updated_alpha = ((expt - expt_sq) * expt) / variance;
-  const updated_beta = ((expt - expt_sq) * (1 - expt)) / variance;
+  const updatedAlpha = ((expt - expt_sq) * expt) / variance;
+  const updatedBeta = ((expt - expt_sq) * (1 - expt)) / variance;
 
-  return [updated_alpha, updated_beta, c];
+  return [updatedAlpha, updatedBeta, c];
 };
 
 export {
   argmax,
-  divergence_gaussian,
-  divergence_beta,
+  divergenceGaussian,
+  divergenceBeta,
   update,
-  expected_information_gain,
+  expectedInformationGain,
   GAMMA,
   LAMBDA,
   MU_PRIOR,

--- a/src/server/utils/fp.ts
+++ b/src/server/utils/fp.ts
@@ -1,13 +1,33 @@
-function id<T>(x : T) : T {
+function id<T>(x: T): T {
   return x;
 }
 
-function uproduct<T, U, W>(f : (x : T) => U, g : (x : T) => W) : (x : T) => [U, W] {
-  return (x : T) => [f(x), g(x)]
+function uproduct<T, U, W>(f: (x: T) => U, g: (x: T) => W): (x: T) => [U, W] {
+  return (x: T) => [f(x), g(x)];
 }
 
-function product<T, U, V, W>(f : (x : T) => U, g : (y : V) => W) : (x : T, y : V) => [U, W] {
-  return (x : T, y : V) => [f(x), g(y)];
+function product<T, U, V, W>(
+  f: (x: T) => U,
+  g: (y: V) => W
+): (x: T, y: V) => [U, W] {
+  return (x: T, y: V) => [f(x), g(y)];
 }
 
-export { id, uproduct, product }
+function mapReducePartial<T, U, V>(
+  f: (x: T) => U,
+  g: (y: V, z: U) => V,
+  b: V
+): (xs: T[]) => V {
+  return (xs) => xs.map(f).reduce(g, b);
+}
+
+function mapReduce<T, U, V>(
+  f: (x: T) => U,
+  g: (y: V, z: U) => V,
+  b: V,
+  xs: T[]
+): V {
+  return mapReducePartial(f, g, b)(xs);
+}
+
+export { id, uproduct, product, mapReducePartial, mapReduce };


### PR DESCRIPTION
# Description

Implements the `getNext` function to get the next project for a given judge to visit. Modifies schema to add necessary fields. The next project is chosen as follows:
* All projects in the judge's `ignore` list (ones they have visited before) are eliminated
* All projects that are currently being visited are eliminated
* If there are JudgingInstances which haven't been judged matching the judge's prizes, maximizing the number of matching unjudged JudgingInstances is prioritized
* Among all remaining projects, the project maximizing total information gain (across all matching JudgingInstances) is selected
  * with some small probability $\epsilon$, a random project is chosen.

Closes #9

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Self-review and eyeballing. Will be tested extensively once the whole system is up.